### PR TITLE
Update gems to fix nokogiri vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     erubis (2.7.0)
-    json (1.8.2)
-    mini_portile (0.6.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    power_assert (0.2.7)
-    rake (10.4.2)
-    rdoc (4.2.0)
-      json (~> 1.4)
-    test-unit (3.1.8)
+    mini_portile2 (2.8.7)
+    nokogiri (1.16.6)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    power_assert (2.0.3)
+    psych (5.1.2)
+      stringio
+    racc (1.8.0)
+    rake (13.2.1)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
+    stringio (3.1.1)
+    test-unit (3.6.2)
       power_assert
 
 PLATFORMS
@@ -24,4 +28,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   1.11.2
+   2.5.14


### PR DESCRIPTION
This resolves the critical Nokogiri vulnerabilities detected in this gem in Artifact Registry

https://github.com/advisories/GHSA-cr5j-953j-xw5p